### PR TITLE
Fix #22: Remove dependency to WeakReference

### DIFF
--- a/core/src/main/scala/moorka/rx/base/bindings/Binding.scala
+++ b/core/src/main/scala/moorka/rx/base/bindings/Binding.scala
@@ -2,27 +2,47 @@ package moorka.rx.base.bindings
 
 import moorka.rx.base.{Rx, Source}
 
-import scala.ref.WeakReference
-
 /**
  * @author Aleksey Fomkin <aleksey.fomkin@gmail.com>
  */
-private[rx] class Binding[From, To](parent: Source[From],
+private[rx] class Binding[From, To](val parent: Source[From],
                                     lambda: From ⇒ Rx[To]) extends Source[To] {
 
+  val bindingContext: Option[Rx[_]] = bindingStack.headOption
+  
   def run(x: From) = {
     // Cleanup upstreams
-    upstreams.foreach(_.kill())
-    upstreams = Nil
-    // Pull value from upstream
-    pull(lambda(x))
+    val currentBindingStack = bindingStack
+    currentBindingStack.push(this)
+    killUpstreams()
+    try {
+      // Pull value from upstream
+      pull(lambda(x))
+    }
+    finally {
+      currentBindingStack.pop()
+    }
   }
 
-  val ref = WeakReference(this)
-  parent.attachBinding(ref)
+  parent.attachBinding(this)
+
+  override private[rx] def killUpstreams(): Unit = {
+    val optionThis = Some(this)
+    upstreams foreach {
+      case upstream: Binding[_, _] ⇒
+        upstream.parent match {
+          case binding: Binding[_, _] if binding.bindingContext == optionThis ⇒
+            binding.kill()
+          case _ ⇒ ()
+        }
+        upstream.kill()
+      case x ⇒
+        x.kill()
+    }
+  }
 
   override def kill(): Unit = {
-    parent.detachBinding(ref)
+    parent.detachBinding(this)
     super.kill()
   }
 

--- a/core/src/main/scala/moorka/rx/base/bindings/package.scala
+++ b/core/src/main/scala/moorka/rx/base/bindings/package.scala
@@ -1,0 +1,21 @@
+package moorka.rx.base
+
+import scala.collection.mutable
+
+/**
+ * @author Aleksey Fomkin <aleksey.fomkin@gmail.com>
+ */
+package object bindings {
+
+  private val _bindingStack = new ThreadLocal[mutable.Stack[Rx[_]]]()
+  
+  private[bindings] def bindingStack = {
+    val value = _bindingStack.get()
+    if (value == null) {
+      val newValue = mutable.Stack[Rx[_]]()
+      _bindingStack.set(newValue)
+      newValue
+    }
+    else value
+  }
+}

--- a/core/src/main/scala/moorka/rx/legacy/package.scala
+++ b/core/src/main/scala/moorka/rx/legacy/package.scala
@@ -1,8 +1,8 @@
 package moorka.rx
 
-import moorka.rx._
 import moorka.rx.base.Source
 import moorka.rx.base.bindings.StatefulBinding
+import scala.language.postfixOps
 
 /**
  * State/Chanel API from moorka < 0.4.0 
@@ -15,21 +15,7 @@ package object legacy {
   implicit final class RxLegacyOps[A](val self: Rx[A]) extends AnyVal {
 
     def subscribe(f: A ⇒ Unit)(implicit reaper: Reaper = Reaper.nice): Rx[Unit] = {
-      self match {
-        case x: Var[A] ⇒
-          val us = x.drop(1).foreach(f).mark()
-          x.addUpstream(us)
-          us
-        case x: StatefulBinding[_, A] ⇒
-          val us = x.drop(1).foreach(f).mark()
-          x.addUpstream(us)
-          us
-        case x: Source[A] ⇒
-          val us = x.foreach(f).mark()
-          x.addUpstream(us)
-          us
-        case _ ⇒ throw new RxOperationException("This Rx is not source")
-      }
+      self foreach f mark
     }
 
     def listen(f: ⇒ Unit)(implicit reaper: Reaper = Reaper.nice) = {
@@ -40,7 +26,6 @@ package object legacy {
       self match {
         case x: Source[A] ⇒
           val us = x.foreach(_ ⇒ f).mark()
-          x.addUpstream(us)
           us
         case _ ⇒ throw new RxOperationException("This Rx is not source")
       }


### PR DESCRIPTION
When lambda of flatMap invoked again we kill all bindings created inside this lambda before. It should works in single threaded environment.