### PR TITLE
Fix #27: New component design

### DIFF
--- a/core/src/main/scala/moorka/rx/base/ops/RxOps.scala
+++ b/core/src/main/scala/moorka/rx/base/ops/RxOps.scala
@@ -1,7 +1,6 @@
 package moorka.rx.base.ops
 
 import moorka.rx.base._
-import moorka.rx.death.Reaper
 
 import scala.concurrent._
 
@@ -120,9 +119,4 @@ final class RxOps[A](val self: Rx[A]) extends AnyVal {
   }
 
   def toFuture: Future[A] = new FutureRx(self)
-
-  def mark()(implicit reaper: Reaper) = {
-    reaper.mark(self)
-    self
-  }
 }

--- a/core/src/main/scala/moorka/rx/legacy/package.scala
+++ b/core/src/main/scala/moorka/rx/legacy/package.scala
@@ -1,5 +1,6 @@
 package moorka.rx
 
+import moorka.rx._
 import moorka.rx.base.{Killer, Source}
 import moorka.rx.base.bindings.{Binding, StatefulBinding}
 import scala.language.postfixOps

--- a/core/src/main/scala/moorka/rx/package.scala
+++ b/core/src/main/scala/moorka/rx/package.scala
@@ -2,6 +2,7 @@ package moorka
 
 import moorka.rx.base.ops.{RxSeqOps, RxOps}
 import moorka.rx.collection.ops.BufferOps
+import moorka.rx.death.Reaper
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
@@ -42,6 +43,13 @@ package object rx {
 
   implicit def ToRxSeqOps[A](x: Rx[Seq[A]]): RxSeqOps[A] = new RxSeqOps[A](x)
 
+  implicit class MortalOps[T <: Mortal](val self: T) extends AnyVal {
+    def mark()(implicit reaper: Reaper): T = {
+      reaper.mark(self)
+      self
+    }
+  }
+  
   implicit class FutureOps[A](val self: Future[A]) extends AnyVal {
     def toRx(implicit executor: ExecutionContext): Rx[Try[A]] = {
       new base.RxFuture(self)

--- a/moorka-ui/src/main/scala/moorka/ui/components/base/Component.scala
+++ b/moorka-ui/src/main/scala/moorka/ui/components/base/Component.scala
@@ -1,10 +1,13 @@
 package moorka.ui.components.base
 
-import moorka.ui.element.ElementBase
+import moorka.ui.Ref
+import moorka.ui.element.{ElementBase, ElementEntry}
 
 /**
  * @author Aleksey Fomkin <aleksey.fomkin@gmail.com>
  */
-trait Component {
-  val el: ElementBase
+abstract class Component(tagName: String = "div") extends ElementBase {
+  val ref = Ref(tagName)
+  @deprecated("Use component it self instead el", "0.5.0")
+  final val el = this
 }

--- a/moorka-ui/src/main/scala/moorka/ui/element/Element.scala
+++ b/moorka-ui/src/main/scala/moorka/ui/element/Element.scala
@@ -11,29 +11,5 @@ class Element(tagName: String, children: Seq[ElementEntry]) extends ElementBase 
 
   val ref = Ref(tagName)
 
-  var observers:List[Mortal] = Nil
-
-  children.foreach {
-    case e: ElementBase =>
-      observers ::= e
-      e.parent = this
-      ref.appendChild(e.ref)
-    case sequence: ElementSequence =>
-      sequence.value.foreach { x =>
-        x.parent = this
-        observers ::= x
-      }
-      ref.appendChildren(sequence.value.map(_.ref))
-    case processor: ElementExtension =>
-      observers ::= processor
-      processor.start(this)
-  }
-
-  override def kill(): Unit = {
-    super.kill()
-    observers.foreach(_.kill())
-    observers = Nil
-  }
-
-  EventProcessor.registerElement(this)
+  fillSeq(children)
 }

--- a/moorka-ui/src/main/scala/moorka/ui/package.scala
+++ b/moorka-ui/src/main/scala/moorka/ui/package.scala
@@ -41,10 +41,7 @@ package object ui {
   val RenderAPI = render.RenderAPI
   val Ref = render.Ref
 
-  implicit def FromComponentToElement(x: Component): ElementBase = x.el
-
-  implicit def ToFutureElement[T](x: Future[T])(implicit ev1: T => ElementBase,
-                                  ec: ExecutionContext): FutureElement = {
-    new FutureElement(x.map(ev1))
+  implicit def ToFutureElement[T <: ElementBase](x: Future[T])(implicit ec: ExecutionContext): FutureElement = {
+    new FutureElement(x)
   }
 }

--- a/moorka-ui/src/main/scala/moorka/ui/render/RenderAPI.scala
+++ b/moorka-ui/src/main/scala/moorka/ui/render/RenderAPI.scala
@@ -61,7 +61,6 @@ object RenderAPI {
   def ?(msg: Message) = {
     val p = Promise[Any]()
     val pair = (msg(3).toString, p)
-    println(s"promise ${msg(3).toString} added")
     promises = promises + pair
     this ! msg
     p.future


### PR DESCRIPTION
Component became an ElementBase. New syntax
```scala
class MyComponent(state: MyComponentState) extends Component("li") {
  fill {
    class := "item",
    state.value
  }
}
```