### PR TITLE
Fixed #79: Fix until sign and add takeWhile

### DIFF
--- a/moorka/src/main/scala/moorka/rx/ops/RxOps.scala
+++ b/moorka/src/main/scala/moorka/rx/ops/RxOps.scala
@@ -24,6 +24,14 @@ final class RxOps[A](val self: Rx[A]) extends AnyVal {
   def until(f: A ⇒ Boolean)
            (implicit reaper: Reaper = Reaper.nice): Rx[Unit] = {
     self >>= { x ⇒
+      if (f(x)) Killer
+      else Dummy
+    }
+  }
+
+  def takeWhile(f: A ⇒ Boolean)
+           (implicit reaper: Reaper = Reaper.nice): Rx[Unit] = {
+    self >>= { x ⇒
       if (!f(x)) Killer
       else Dummy
     }

--- a/moorka/src/test/scala/RxSuite.scala
+++ b/moorka/src/test/scala/RxSuite.scala
@@ -13,7 +13,7 @@ import scala.language.implicitConversions
 object RxSuite extends TestSuite {
 
   implicit def toRx[T](x: T): Rx[T] = Val(x)
-  
+
   val tests = TestSuite {
 
     "check kill behavior" - {
@@ -150,11 +150,29 @@ object RxSuite extends TestSuite {
         assert(calls == 1)
       }
 
-      "until() should kill after f returns false" - {
+      "until() should kill after f returns true" - {
         var calls = 0
         val ch = Channel[Int]()
         System.gc()
         ch until { x ⇒
+          calls += 1
+          x >= 2
+        }
+        System.gc()
+        System.gc()
+        ch.pull(1)
+        System.gc()
+        ch.pull(2)
+        System.gc()
+        ch.pull(3)
+        assert(calls == 2)
+      }
+
+      "takeWhile() should kill after f returns false" - {
+        var calls = 0
+        val ch = Channel[Int]()
+        System.gc()
+        ch takeWhile  { x ⇒
           calls += 1
           x < 2
         }


### PR DESCRIPTION
`until` now works correctly. Also I added `takeWhile` method. `while` is reserved keyword, so I didn't have possibility to create `while` method (except unusable in this case `while` syntax). I got `takeWhile` name from [ReactiveX implementation](http://reactivex.io/documentation/operators/takewhile.html).
