### PR TITLE
Closes #50: Add batch processing in Vaska

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,11 +21,9 @@ val commonSettings = Seq(
 )
 
 val utestSetting = Seq(
-  testFrameworks += new TestFramework("utest.runner.Framework")
+  testFrameworks += new TestFramework("utest.runner.Framework"),
+  libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1" % "test"
 )
-
-val utestSettingsJS = utestSetting :+ (libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1" % "test")
-val utestSettingsJVM = utestSetting :+ (libraryDependencies += "com.lihaoyi" %% "utest" % "0.3.1" % "test")
 
 val publishSettings = moorkaVersion.endsWith("SNAPSHOT") match {
   case true => Seq(
@@ -47,8 +45,8 @@ val publishSettings = moorkaVersion.endsWith("SNAPSHOT") match {
 
 lazy val moorka = crossProject
   .crossType(CrossType.Pure)
-  .jsSettings(utestSettingsJS:_*)
-  .jvmSettings(utestSettingsJVM:_*)
+  .jsSettings(utestSetting:_*)
+  .jvmSettings(utestSetting:_*)
   .settings(publishSettings:_*)
   .settings(commonSettings:_*)
   .settings(
@@ -64,7 +62,7 @@ lazy val vaska = crossProject
   .settings(
     unmanagedResourceDirectories in Compile += file("vaska") / "shared" / "src" / "main" / "resources"
   )
-  .jsSettings(utestSettingsJS:_*)
+  .jsSettings(utestSetting:_*)
   .jsSettings(
     libraryDependencies ++= Seq(
       "org.webjars" % "es6-shim" % "0.20.2" % "test"
@@ -76,7 +74,7 @@ lazy val vaska = crossProject
     ),
     jsDependencies += ProvidedJS / "vaska.js"
   )
-  .jvmSettings(utestSettingsJVM:_*)
+  .jvmSettings(utestSetting:_*)
   .settings(publishSettings:_*)
   .settings(commonSettings:_*)
   .settings(normalizedName := "vaska")
@@ -92,12 +90,12 @@ lazy val felix = crossProject
     normalizedName := "felix",
     unmanagedResourceDirectories in Compile += file("felix") / "shared" / "src" / "main" / "resources"
   )
-  .jsSettings(utestSettingsJS:_*)
+  .jsSettings(utestSetting:_*)
   .jsConfigure(_.dependsOn(vaskaJS  % "compile->compile;test->test", moorkaJS))
   .jsSettings(
     jsDependencies += ProvidedJS / "felix.js"
   )
-  .jvmSettings(utestSettingsJVM:_*)
+  .jvmSettings(utestSetting:_*)
   .jvmSettings(
     libraryDependencies += "org.java-websocket" % "Java-WebSocket" % "1.3.0"
   )

--- a/felix/jvm/src/main/scala/felix/WebSocketJSAccess.scala
+++ b/felix/jvm/src/main/scala/felix/WebSocketJSAccess.scala
@@ -30,7 +30,7 @@ class WebSocketJSAccess(webSocket: WebSocket) extends JSAccess {
   }
 
   /**
-   * Abstract method sends message to remote page 
+   * Abstract method sends message to remote page
    */
   def send(args: Seq[Any]): Unit = {
     val message = seqToJSON(args)

--- a/felix/shared/src/test/scala/felix/EventProcessorSuite.scala
+++ b/felix/shared/src/test/scala/felix/EventProcessorSuite.scala
@@ -22,9 +22,9 @@ object EventProcessorSuite extends TestSuite {
     ep.registerElement(this)
   }
 
-  
+
   def createProcessor(f: Seq[Any] ⇒ Action): (JSAccess, EventProcessor) = {
-    
+
     val jsAccess = new JSAccess {
       implicit val executionContext: ExecutionContext = utest.ExecutionContext.RunNow
       def send(args: Seq[Any]): Unit = {

--- a/vaska/js/src/main/scala/vaska/NativeJSAccess.scala
+++ b/vaska/js/src/main/scala/vaska/NativeJSAccess.scala
@@ -1,5 +1,6 @@
 package vaska
 
+import scala.collection.mutable
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
 
@@ -18,6 +19,8 @@ final class NativeJSAccess(scope: js.Dynamic) extends JSAccess {
   implicit val executionContext = {
     scala.scalajs.concurrent.JSExecutionContext.runNow
   }
+
+  protected val batchedRequests = mutable.Queue[Request]()
 
   // Receive messages from page and resolve promises
   scope.onmessage = { event: js.Dynamic ⇒
@@ -38,6 +41,34 @@ final class NativeJSAccess(scope: js.Dynamic) extends JSAccess {
   override def platformDependentPack(value: Any): Any = value match {
     case xs: Seq[Any] ⇒ js.Array(xs:_*)
     case x ⇒ super.platformDependentPack(x)
+  }
+
+  override protected def sendRequest(request: Request): Unit = {
+    batchedRequests.enqueue(request)
+    if (batchedRequests.size == 1) {
+      // accumulate requests until new event loop cycle is started
+      scala.scalajs.js.timers.setTimeout(0) {
+        val requests = batchedRequests.dequeueAll(_ ⇒ true).toSeq
+        if (requests.size == 1) {
+          val req = requests.head
+          sendRequest(req.args) { e ⇒
+            req.resultPromise.failure(e)
+          }
+        } else {
+          sendRequestsBatch(requests)
+        }
+      }
+    }
+  }
+
+  protected def sendRequestsBatch(requests: Seq[Request]): Unit = {
+    val args = "batch" +: requests.map(_.args)
+
+    sendRequest(args) { e ⇒
+      requests.foreach { request ⇒
+        request.resultPromise.failure(e)
+      }
+    }
   }
 
   def send(args: Seq[Any]): Unit = {

--- a/vaska/shared/src/main/resources/vaska.js
+++ b/vaska/shared/src/main/resources/vaska.js
@@ -235,11 +235,21 @@
 
       this.receive = function (data) {
         if (workerProtocolDebugEnabled) console.log('->', data);
+
+        // requests batch processing
+        if (data[0] === "batch") {
+          var requests = data.slice(1);
+          requests.forEach(function (request) {
+            self.receive(request);
+          });
+          return;
+        }
+
         var reqId = data[0],
             method = data[1],
             rawArgs = data.slice(2),
-            args = unpackArgs(rawArgs.concat()),
-            tmp = null;
+            args = unpackArgs(rawArgs.concat());
+
         switch (method) {
           // Misc
           case 'init':

--- a/vaska/shared/src/test/scala/vaska/JSAccessSuite.scala
+++ b/vaska/shared/src/test/scala/vaska/JSAccessSuite.scala
@@ -1,5 +1,6 @@
+package vaska
+
 import utest._
-import vaska.{Hook, JSArray, JSObj, JSAccess}
 
 import scala.util.{Failure, Success}
 
@@ -13,7 +14,7 @@ object JSAccessSuite extends TestSuite {
     implicit val executionContext = utest.ExecutionContext.RunNow
 
     var outgoing = List.empty[Seq[Any]]
-    
+
     def receive(msg: Any*) = {
       val reqId = msg(0).asInstanceOf[Int]
       if (reqId == -1) {
@@ -32,9 +33,9 @@ object JSAccessSuite extends TestSuite {
       outgoing ::= args
     }
   }
-  
+
   val tests = TestSuite {
-    
+
     "Check packing" - {
       val acc = new TestJSAccess()
       "JSArray" - {
@@ -71,7 +72,7 @@ object JSAccessSuite extends TestSuite {
         assert(res == Seq("@hook_failure"))
       }
     }
-    
+
     "Check unpacking" - {
       val acc = new TestJSAccess()
       "JSObj  " - {
@@ -99,16 +100,16 @@ object JSAccessSuite extends TestSuite {
         assert(res == null)
       }
     }
-    
+
     "Check request" - {
 
       import utest.ExecutionContext.RunNow
-      
+
       "Success" - {
         val acc = new TestJSAccess()
-        val res = acc.request[Float]("get", acc.obj("myObj"), "width")
+        val req = acc.request[Float]("get", acc.obj("myObj"), "width")
         var calls = 0
-        res.onComplete {
+        req.onComplete {
           case Success(x) ⇒
             assert(x == 100f)
             calls += 1
@@ -121,9 +122,9 @@ object JSAccessSuite extends TestSuite {
 
       "Failure" - {
         val acc = new TestJSAccess()
-        val res = acc.request[Float]("get", acc.obj("myObj"), "width")
+        val req = acc.request[Float]("get", acc.obj("myObj"), "width")
         var calls = 0
-        res.onFailure {
+        req.onFailure {
           case err ⇒
             assert(err.getMessage == "error")
             calls += 1


### PR DESCRIPTION
- NativeJSAccess now use batch processing for requests. It saves requests in the local queue and send all requests as a single query to the main thread. If batch sending failed, all requests in the batch failed too.
- vaska.js now can handle bathced requests (see receive method).
- Tests adaptation.
- build.sbt minor improvements.
